### PR TITLE
Increased future Security of app by removing unsecure AsynStorage on AuthContext / General housekeeping.

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -19,7 +19,8 @@ export default {
           locationAlwaysAndWhenInUsePermission: "This app needs access to your location to show maps and navigation.",
           isAndroidBackgroundLocationEnabled: false,
           isAndroidForegroundServiceEnabled: false
-        }
+        },
+        "expo-secure-store"
       ]
     ],
     ios: {

--- a/modules/auth0/AuthContext.tsx
+++ b/modules/auth0/AuthContext.tsx
@@ -9,7 +9,7 @@ import * as AuthSession from "expo-auth-session";
 import { REACT_APP_AUTH0_DOMAIN, REACT_APP_AUTH0_CLIENT_ID } from "@env";
 import { User, AuthContextType } from "./types";
 import { gpsService } from "../navigation";
-import AsyncStorage from "@react-native-async-storage/async-storage";
+import * as SecureStore from "expo-secure-store";
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
@@ -40,11 +40,11 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     }
   );
 
-  function clearAllData() {
+  const clearAllData = async ()=> {
     gpsService.deleteAllWaypoints();
     gpsService.deleteAllRoutes();
     gpsService.stopLocationUpdates();
-    AsyncStorage.clear();
+    await SecureStore.deleteItemAsync('userToken');
   }
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "expo-crypto": "~14.1.5",
         "expo-dev-client": "~5.2.4",
         "expo-location": "~18.1.6",
+        "expo-secure-store": "~15.0.7",
         "expo-status-bar": "~2.2.3",
         "lucide-react-native": "^0.537.0",
         "react": "19.0.0",
@@ -6527,6 +6528,15 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-secure-store": {
+      "version": "15.0.7",
+      "resolved": "https://registry.npmjs.org/expo-secure-store/-/expo-secure-store-15.0.7.tgz",
+      "integrity": "sha512-9q7+G1Zxr5P6J5NRIlm86KulvmYwc6UnQlYPjQLDu1drDnerz6AT6l884dPu29HgtDTn4rR0heYeeGFhMKM7/Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-status-bar": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "react-native-reanimated": "~3.17.4",
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "4.11.1",
-    "react-native-web": "^0.20.0"
+    "react-native-web": "^0.20.0",
+    "expo-secure-store": "~15.0.7"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/screens/MapTabScreen.tsx
+++ b/screens/MapTabScreen.tsx
@@ -32,6 +32,13 @@ const MapTabScreen = () => {
     longitudeDelta: initialLongitudeDelta,
   };
 
+    useEffect(() => {
+    const timer = setTimeout(() => {
+      setShouldRenderMap(true);
+    }, 800);
+    return () => clearTimeout(timer);
+  }, []);
+
   // Batched initialization - runs once on mount
   useEffect(() => {
     const initializeData = async () => {
@@ -67,12 +74,6 @@ const MapTabScreen = () => {
     }
   }, [isWaypointDeleteDisplayed]);
 
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      setShouldRenderMap(true);
-    }, 800);
-    return () => clearTimeout(timer);
-  }, []);
 
   const handleLocationPress = async () => {
     try {


### PR DESCRIPTION


## Summary
Noticed my earlier implementation of Auth0 had a AsyncStorage use case for deleting that information which , 1. Was not deleting anything because i was not storing anything.  2. When implementation of true Auth0 JWT use is started, I will be using SecureStore due to its encrypted nature, so I put SecureStore into the AuthContext.tsx module and imported npm modules for SecureStore in the app.

## Changes Made
- Removed AsyncStore on AuthContext.tsx for future implementation of Auth0_using SecureStore
- Moved a useEffect in MapTabScreen to be more clear on intention for it to re-render location of user from far out view to closer view. Will most likely update the way this works. 

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)  
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Maintenance/refactor (no functional changes)
- [ ] 🚀 Performance improvement
- [ ] 🎨 UI/UX improvement


## Testing
- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Verified existing functionality still works
- [ ] Added/updated tests if applicable

## Screenshots/Videos (if applicable)
<!-- Add before/after screenshots or screen recordings -->


## Related Issues
Closes #[issue-number]
<!-- or -->
Related to #[issue-number]

## Additional Notes
<!-- Any additional context, concerns, or things reviewers should know -->

## Review Checklist
- [ ] Code follows project style guidelines
- [ ] TypeScript types are properly defined
- [ ] Navigation param lists use type (following React Navigation docs)
- [ ] Component props use interface (slightly more common, easier to extend)
- [ ] API responses/data models use type (more flexible)
- [ ] Utility/union types use type (only option for unions)
- [ ] Navigation flows work correctly
- [ ] No memory leaks or performance issues introduced

