### PR TITLE
AntIcon had issues with rendering when we downgraded from EXPO SDK54 …

### DIFF
--- a/modules/navigation/TabsNavigator.tsx
+++ b/modules/navigation/TabsNavigator.tsx
@@ -2,7 +2,6 @@ import { styles } from "../../styles";
 import { FontAwesome5 } from '@expo/vector-icons';
 import FontAwesome from '@expo/vector-icons/FontAwesome';
 import Ionicons from '@expo/vector-icons/Ionicons';
-import AntDesign from '@expo/vector-icons/AntDesign';
 import MapTabScreen from "../../screens/MapTabScreen";
 import RoutesTabScreen from "../../screens/RoutesTabScreen";
 import OfflineMapsScreen from "./../../screens/OfflineMapsTabScreen";
@@ -44,7 +43,7 @@ const TabsNavigator = () => {
         component={OfflineMapsScreen}
         options={{
           tabBarIcon: ({ color, size }) => (
-            <AntDesign name="cloud-download" size={size} color={color}/>
+            <Ionicons name="cloud-download-outline" size={size} color={color}/>
           ),
         }}
       />


### PR DESCRIPTION
AntIcon had issues with rendering when we downgraded from EXPO SDK54 to EXPO SDK53

## Summary
AntIcon was causing issue with rendering due to downgrade from EXPO 54 to EXPO 53

## Changes Made
-  AntIcon had issues with rendering when we downgraded from EXPO SDK54 to EXPO SDK53

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)  
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Maintenance/refactor (no functional changes)
- [ ] 🚀 Performance improvement
- [ ] 🎨 UI/UX improvement


## Testing
- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Verified existing functionality still works
- [ ] Added/updated tests if applicable

## Screenshots/Videos (if applicable)
<!-- Add before/after screenshots or screen recordings -->


## Related Issues
Closes #[issue-number]
<!-- or -->
Related to #[issue-number]

## Additional Notes
<!-- Any additional context, concerns, or things reviewers should know -->

## Review Checklist
- [x] Code follows project style guidelines
- [x] TypeScript types are properly defined
- [ ] Navigation param lists use type (following React Navigation docs)
- [ ] Component props use interface (slightly more common, easier to extend)
- [ ] API responses/data models use type (more flexible)
- [ ] Utility/union types use type (only option for unions)
- [ ] Navigation flows work correctly
- [x] No memory leaks or performance issues introduced

